### PR TITLE
Created NGO approval process. Closes #86

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -25,4 +25,7 @@ urlpatterns = [
         auth_views.password_reset_confirm, name='password_reset_confirm'),
     url(r'^reset/done/$', auth_views.password_reset_complete, name='password_reset_complete'),
     url(r'^country/states/$', views.StateAjaxView, name='states_of_country'),
+    url(r'^ngo_approval/(?P<pk>\d+)/$', views.ngo_approval, name="ngo_approval"),
+    url(r'^(?P<pk>\d+)/ngo_approve/$', views.approve_ngo, name="approve_ngo"),
+    url(r'^(?P<pk>\d+)/ngo_reject/$', views.reject_ngo, name="reject_ngo"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,4 @@
+import json
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth import login, update_session_auth_hash
@@ -11,15 +12,22 @@ from django.template.loader import render_to_string
 from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.translation import ugettext_lazy as _
+
 from .forms import SignupForm, UserCompletionForm, ProfileCompletionForm
+from .forms import ProfileForm, UserForm, PasswordChangeForm
 from .forms import OrganizationSignupForm, OrganizationCompletionForm
 from .forms import OrganizationUserForm, OrganizationProfileForm
-from .forms import ProfileForm, UserForm, PasswordChangeForm
-from .tokens import account_activation_token
+
 from educational_need.models import EducationalNeed
-import json
-from .models import State
 from .models import Profile
+from .models import State
+
+from .tokens import account_activation_token as activation_token
+
+
+def send_email(subject, message, toemails):
+    email = EmailMessage(subject, message, to=toemails)
+    email.send()
 
 
 def signup(request):
@@ -32,16 +40,16 @@ def signup(request):
                 user = form.save(commit=False)
                 user.is_active = False
                 user.save()
-                current_site = get_current_site(request)
-                subject = 'Activate your account on Janani Care.'
                 message = render_to_string('accounts/activation_email.html', {
-                    'user':user, 'domain':current_site.domain,
+                    'user': user, 'domain': get_current_site(request),
                     'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-                    'token': account_activation_token.make_token(user),
+                    'token': activation_token.make_token(user),
                 })
-                toemail = form.cleaned_data.get('email')
-                email = EmailMessage(subject, message, to=[toemail])
-                email.send()
+                send_email(
+                    subject='Activate your account on Janani Care',
+                    message=message,
+                    toemails=[form.cleaned_data.get('email')],
+                    )
                 return render(request, 'accounts/activation_pending.html')
         else:
             form = SignupForm()
@@ -57,7 +65,8 @@ def activate(request, uidb64, token):
 
     if request.method == 'POST':
         user_form = UserCompletionForm(request.POST, instance=user)
-        profile_form = ProfileCompletionForm(request.POST, instance=user.profile)
+        profile_form = ProfileCompletionForm(request.POST,
+                                             instance=user.profile)
         if user_form.is_valid() and profile_form.is_valid():
             user.is_active = True
             user_form.save()
@@ -69,7 +78,7 @@ def activate(request, uidb64, token):
     else:
         user_form = UserCompletionForm()
         profile_form = ProfileCompletionForm()
-        if user is not None and account_activation_token.check_token(user, token):
+        if user is not None and activation_token.check_token(user, token):
             pass
         else:
             return HttpResponse('Activation link is invalid!')
@@ -97,7 +106,8 @@ def update_profile(request):
     if request.method == 'POST':
         current_email = request.user.email
         user_form = UserForm(request.POST, instance=request.user)
-        profile_form = ProfileForm(request.POST, request.FILES, instance=request.user.profile)
+        profile_form = ProfileForm(request.POST, request.FILES,
+                                   instance=request.user.profile)
         if user_form.is_valid() and profile_form.is_valid():
             user = user_form.save(commit=False)
             profile = profile_form.save(commit=False)
@@ -107,23 +117,27 @@ def update_profile(request):
 
                 # Send activation email
                 current_site = get_current_site(request)
-                subject = 'Confirm your new email address on Janani Care.'
-                message = render_to_string('accounts/email_confirmation_email.html', {
-                    'user': user, 'domain': current_site.domain,
-                    'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-                })
-                toemail = profile.unconfirmed_email
-                email = EmailMessage(subject, message, to=[toemail])
-                email.send()
+                message = render_to_string(
+                    'accounts/email_confirmation_email.html', {
+                        'user': user, 'domain': current_site.domain,
+                        'uid': urlsafe_base64_encode(force_bytes(user.pk))})
+                send_email(
+                    subject='Confirm your new email address on Janani Care',
+                    message=message,
+                    toemails=[profile.unconfirmed_email],
+                    )
 
+                # Display message for the user
                 messages.warning(request, _(
-                    ''' Your have requested an email change to %s! We have just sent
-                    you a message to %s with a confirmation link inside. You have to
-                    click the link in the message to confirm your new email address.
-                    If you don't click the link, %s will continue to be your only 
-                    active email address. If for some reason the message doesn't
-                    arrive, try to change the email again or contact administration.'''
-                    % (profile.unconfirmed_email, profile.unconfirmed_email, current_email)
+                    ''' Your have requested an email change to %s! We have just
+                    sent you a message to %s with a confirmation link inside.
+                    You have to click the link in the message to confirm your
+                    new email address. If you don't click the link, %s will
+                    continue to be your only active email address. If for some
+                    reason the message doesn't arrive, try to change the email
+                    again or contact administration.'''
+                    % (profile.unconfirmed_email, profile.unconfirmed_email,
+                       current_email)
                 ))
             user.save()
             profile.save()
@@ -148,7 +162,8 @@ def update_ngo_profile(request):
     if request.method == 'POST':
         current_email = request.user.email
         user_form = OrganizationUserForm(request.POST, instance=request.user)
-        profile_form = OrganizationProfileForm(request.POST, request.FILES, instance=request.user.profile)
+        profile_form = OrganizationProfileForm(request.POST, request.FILES,
+                                               instance=request.user.profile)
         if user_form.is_valid() and profile_form.is_valid():
             user = user_form.save(commit=False)
             profile = profile_form.save(commit=False)
@@ -158,23 +173,26 @@ def update_ngo_profile(request):
 
                 # Send activation email
                 current_site = get_current_site(request)
-                subject = 'Confirm your new email address on Janani Care.'
-                message = render_to_string('accounts/email_confirmation_email.html', {
-                    'user': user, 'domain': current_site.domain,
-                    'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-                })
-                toemail = profile.unconfirmed_email
-                email = EmailMessage(subject, message, to=[toemail])
-                email.send()
+                message = render_to_string(
+                    'accounts/email_confirmation_email.html', {
+                        'user': user, 'domain': current_site.domain,
+                        'uid': urlsafe_base64_encode(force_bytes(user.pk))})
+                send_email(
+                    subject='Confirm your new email address on Janani Care',
+                    message=message,
+                    toemails=[profile.unconfirmed_email]
+                )
 
                 messages.warning(request, _(
-                    ''' Your have requested an email change to %s! We have just sent
-                    you a message to %s with a confirmation link inside. You have to
-                    click the link in the message to confirm your new email address.
-                    If you don't click the link, %s will continue to be your only 
-                    active email address. If for some reason the message doesn't
-                    arrive, try to change the email again or contact administration.'''
-                    % (profile.unconfirmed_email, profile.unconfirmed_email, current_email)
+                    ''' Your have requested an email change to %s! We have just
+                    sent you a message to %s with a confirmation link inside.
+                    You have to click the link in the message to confirm your
+                    new email address. If you don't click the link, %s will
+                    continue to be your only active email address. If for some
+                    reason the message doesn't arrive, try to change the email
+                    again or contact administration.'''
+                    % (profile.unconfirmed_email, profile.unconfirmed_email,
+                       current_email)
                 ))
             user.save()
             profile.save()
@@ -233,7 +251,10 @@ def StateAjaxView(request):
     """function to render the states accourding to the city passed"""
     try:
         country_id = request.GET.get('country_id')
-        return HttpResponse(json.dumps(tuple(i for i in State.objects.filter(country_id=country_id).values('name','id','code'))),content_type='application/json')
+        return HttpResponse(
+            json.dumps(tuple(i for i in State.objects.filter(
+                        country_id=country_id).values('name', 'id', 'code'))),
+            content_type='application/json')
     except Exception as e:
         return HttpResponse(json.dumps([]),content_type='application/json')
 
@@ -248,17 +269,19 @@ def organization_signup(request):
                 user = form.save(commit=False)
                 user.is_active = False
                 user.save()
+
                 current_site = get_current_site(request)
-                subject = 'Activate your organization account on Janani Care.'
                 message = render_to_string(
                     'accounts/organization_activation_email.html', {
                         'user': user, 'domain': current_site.domain,
                         'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-                        'token': account_activation_token.make_token(user),
+                        'token': activation_token.make_token(user),
                     })
-                toemail = form.cleaned_data.get('email')
-                email = EmailMessage(subject, message, to=[toemail])
-                email.send()
+                send_email(
+                    subject='Activate your NGO account on Janani Care',
+                    message=message,
+                    toemails=[form.cleaned_data.get('email')]
+                )
                 return render(request, 'accounts/activation_pending.html')
         else:
             form = OrganizationSignupForm()
@@ -286,15 +309,15 @@ def activate_organization(request, uidb64, token):
             user.save()
             # Send email to admin
             current_site = get_current_site(request)
-            subject = 'New NGO registration on Janani Care.'
             message = render_to_string('accounts/ngo_approval_email.html', {
                 'domain': current_site.domain,
                 'profile': user.profile,
             })
-            toemails = [obj.email for obj in User.objects
-                        .filter(is_staff=True)]
-            email = EmailMessage(subject, message, to=toemails)
-            email.send()
+            send_email(
+                subject='New NGO registration on Janani Care',
+                message=message,
+                toemails=[u.email for u in User.objects.filter(is_staff=True)]
+            )
             # Login user
             login(request, user)
             return render(request, 'accounts/activation_completed.html')
@@ -302,7 +325,7 @@ def activate_organization(request, uidb64, token):
             messages.error(request, _('Please correct the error below.'))
     else:
         form = OrganizationCompletionForm()
-        if user is not None and account_activation_token.check_token(user, token):
+        if user is not None and activation_token.check_token(user, token):
             pass
         else:
             return HttpResponse('Activation link is invalid!')
@@ -328,19 +351,13 @@ def approve_ngo(request, pk):
     ngo.active = True
     ngo.save()
     # Send email to NGO
-    subject = 'Your NGO account was approved'
-    message = '''Dear Sir/Madam,
-we are happy to inform that we approved your NGO account on JananiHome.
-You can log in to your account and start adding volunteers.
-If you have additional questions, please reply to this email.
-
-Best regards,
-JananiHome
-http://jananihome.com'''
-    toemails = [ngo.user.email]
-    email = EmailMessage(subject, message, to=toemails)
-    email.send()
-    messages.info(request, _('Profile was approved. NGO will receive an email with this information.'))    
+    send_email(
+        subject='Your NGO account was approved',
+        message=render_to_string('accounts/ngo_approved_email.html'),
+        toemails=[ngo.user.email]
+    )
+    messages.info(request, _('Profile was approved. NGO will receive an email\
+                             with this information.'))
     return redirect('ngo_approval', ngo.pk)
 
 
@@ -349,18 +366,12 @@ def reject_ngo(request, pk):
     ngo = get_object_or_404(Profile, pk=pk)
     ngo.active = False
     ngo.save()
+    send_email(
+        subject='Your NGO account was rejected',
+        message=render_to_string('accounts/ngo_rejected_email.html'),
+        toemails=[ngo.user.email]
+    )
     # Send email to NGO
-    subject = 'Your NGO account was rejected'
-    message = '''Dear Sir/Madam,
-we are sorry to inform that we didn\'t approve your NGO account on JananiHome.
-You can still log in to your account but you will not able to add volunteers.
-If you have additional questions, please reply to this email.
-
-Best regards,
-JananiHome
-http://jananihome.com'''
-    toemails = [ngo.user.email]
-    email = EmailMessage(subject, message, to=toemails)
-    email.send()
-    messages.info(request, _('Profile was rejected. NGO will receive an email with this information.'))
+    messages.info(request, _('Profile was rejected. NGO will receive an email\
+                             with this information.'))
     return redirect('ngo_approval', ngo.pk)

--- a/templates/accounts/email_confirmation_email.html
+++ b/templates/accounts/email_confirmation_email.html
@@ -1,6 +1,6 @@
 {% autoescape off %}
 Hi {{ user.username }},
-Please click on the link to confirm your new email with Janani Care,
+Please click on the link to confirm your new email with Janani Home,
 
 http://{{ domain }}{% url 'confirm_new_email' uidb64=uid %}
 {% endautoescape %}

--- a/templates/accounts/ngo_approval.html
+++ b/templates/accounts/ngo_approval.html
@@ -1,0 +1,101 @@
+{% extends 'shared/base.html' %}
+{% load widget_tweaks %}
+{% load static %}
+{% load thumbnail %}
+
+{% block meta %}
+    <title>Approve NGO - Janani Home</title>
+    <meta name="description" content="" />
+	<meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block heading %}
+{% endblock heading %}
+
+{% block sidebar %}
+<div class="row">
+    <div class="col-12 text-center mt-5">
+        {% if messages %}
+        {% for message in messages %}
+            {% if 'error' not in message.tags %}
+            <div class="alert alert-{{ message.tags }} alert-dismissable">
+                <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                {{ message }}
+            </div>
+            {% endif %}
+        {% endfor %}
+        {% endif %}
+        <h4>Account Moderation</h4>
+        <form action="{% url 'approve_ngo' ngo.pk %}" method="post">
+            {% csrf_token %}
+            <input type="submit" value="Activate" class="btn btn-success">
+        </form>
+        <br>
+        <form action="{% url 'reject_ngo' ngo.pk %}" method="post">
+            {% csrf_token %}
+            <input type="submit" value="Deactivate" class="btn btn-danger">
+        </form>
+    </div>
+</div>
+{% endblock sidebar %}
+
+{% block content %}
+<h1>Approve NGO</h1>
+<div class="row">
+    <div class="col-12">
+    <div class="card">
+        <div class="card-header">NGO Details</div>
+        <div class="card-block row">
+            <div class="col-md-3 text-center">
+                <div class="profile-image">
+                    {% if not ngo.image %}
+                     <img src="{% static 'img/avatar-male.jpg' %}" height="120" alt="{{ user }}" class="img-fluid" />
+                    {% else %}
+                     <img src="{{ ngo.image|thumbnail_url:'avatar150' }}" alt="{{ user }}" class="img-fluid">
+                    {% endif %}
+                </div>
+            </div>
+            <div class="col-md-7">
+                <div class="row">
+                    <div class="col-md-12">
+                        <h2>{{ ngo.organization_name }}</h2>
+                        <p><span class="profile-label">Username:</span>{{ user.username }}</p>
+                        <p><span class="profile-label">Account Status:</span> {% if ngo.active %}<strong>Active</strong>{% else %}<strong>Inactive</strong> (awaiting moderation){% endif %}</p>
+                    </div>
+                    <div class="col-md-6">
+                        <p>
+                            <span class="profile-label">Country:</span> {{ ngo.country.name }}<br>
+                            <span class="profile-label">State:</span> {{ ngo.state }}<br>
+                            <span class="profile-label">City:</span> {{ ngo.city }}<br>
+                            <span class="profile-label">District:</span> {{ ngo.district }}<br>
+                            <span class="profile-label">Zip:</span> {{ ngo.zip_code }}<br>
+                            <span class="profile-label">Address:</span> {{ ngo.organization_address }}<br>
+                        </p>
+                    </div>
+                    <div class="col-md-6">
+                        <p>
+                            <span class="profile-label">Mobile number:</span> {{ ngo.mobile_number }}<br>
+                            <span class="profile-label">Mobile number 2:</span> {{ ngo.mobile_number_2 }}<br>
+                            <span class="profile-label">Phone number:</span> {{ ngo.phone_number }}<br>
+                            <span class="profile-label">Phone number 2:</span> {{ ngo.phone_number_2 }}<br>
+                            <span class="profile-label">Fax </span> {{ ngo.fax_number }}<br>
+                        </p>
+                    </div>
+                    <div class="col-md-6">
+                        <p>
+                            <span class="profile-label">Addtional contact details:</span> {{ ngo.additional_contact_details }}
+                        </p>
+                    </div>
+                    <div class="col-md-6">
+                        <p><span class="profile-label">E-mail:</span> {{ user.email }}</p>
+                    </div>
+                    <div class="col-md-12">
+                        <p><span class="profile-label">About:</span><i>{{ ngo.about|safe }}</i></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    </div>
+</div>
+{% endblock%}

--- a/templates/accounts/ngo_approval_email.html
+++ b/templates/accounts/ngo_approval_email.html
@@ -1,6 +1,6 @@
 {% autoescape off %}
 New NGO confirmed their registration: {{ profile.user }}: http://{{ domain }}{% url 'admin:accounts_profile_change' profile.pk %}
 
-Go to this page to approve the account:
-http://{{ domain }}{% url 'admin:accounts_profile_change' profile.pk %}
+Go to this page to approve or reject the account:
+http://{{ domain }}{% url 'ngo_approval' profile.pk %}
 {% endautoescape %}

--- a/templates/accounts/ngo_approved_email.html
+++ b/templates/accounts/ngo_approved_email.html
@@ -1,0 +1,9 @@
+Dear Sir/Madam,
+
+we are happy to inform that we approved your NGO account on JananiHome.
+You can log in to your account and start adding volunteers.
+If you have additional questions, please reply to this email.
+
+Best regards,
+JananiHome
+http://jananihome.com

--- a/templates/accounts/ngo_rejected_email.html
+++ b/templates/accounts/ngo_rejected_email.html
@@ -1,0 +1,9 @@
+Dear Sir/Madam,
+
+we are sorry to inform that we didn\'t approve your NGO account on JananiHome.
+You can still log in to your account but you will not able to add volunteers.
+If you have additional questions, please reply to this email.
+
+Best regards,
+JananiHome
+http://jananihome.com


### PR DESCRIPTION
When NGO signs up, admins receive a message with link to moderation page.
On the moderation page, admin can see all NGO details and approve/reject the account.
When admin approves or rejects the account, NGO receives a message with the information.
This view can be used unlimited times, to activate or deactivate any existing NGO accounts.